### PR TITLE
Remove call to mem::uninitialized/zeroed and other improvements

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -4,10 +4,9 @@ extern crate cc;
 use std::path::PathBuf;
 
 fn main() {
-    match pkg_config::probe_library("vorbisidec") {
-        Ok(_) => return,
-        Err(..) => {}
-    };
+    if pkg_config::probe_library("vorbisidec").is_ok() {
+        return;
+    }
 
     let root = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
 

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,5 @@
-extern crate pkg_config;
 extern crate cc;
+extern crate pkg_config;
 
 use std::path::PathBuf;
 
@@ -16,20 +16,20 @@ fn main() {
     println!("cargo:include={}", tremor_include.display());
 
     cc::Build::new()
-                .file("tremor/mdct.c")
-                .file("tremor/block.c")
-                .file("tremor/window.c")
-                .file("tremor/synthesis.c")
-                .file("tremor/info.c")
-                .file("tremor/floor1.c")
-                .file("tremor/floor0.c")
-                .file("tremor/vorbisfile.c")
-                .file("tremor/res012.c")
-                .file("tremor/mapping0.c")
-                .file("tremor/registry.c")
-                .file("tremor/codebook.c")
-                .file("tremor/sharedbook.c")
-                .include(&tremor_include)
-                .include(&ogg_include)
-                .compile("libtremor.a");
+        .file("tremor/mdct.c")
+        .file("tremor/block.c")
+        .file("tremor/window.c")
+        .file("tremor/synthesis.c")
+        .file("tremor/info.c")
+        .file("tremor/floor1.c")
+        .file("tremor/floor0.c")
+        .file("tremor/vorbisfile.c")
+        .file("tremor/res012.c")
+        .file("tremor/mapping0.c")
+        .file("tremor/registry.c")
+        .file("tremor/codebook.c")
+        .file("tremor/sharedbook.c")
+        .include(&tremor_include)
+        .include(&ogg_include)
+        .compile("libtremor.a");
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,28 +31,26 @@ pub enum VorbisError {
 }
 
 impl std::error::Error for VorbisError {
-    fn description(&self) -> &str {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
-            &VorbisError::ReadError(_) => "A read from media returned an error",
-            &VorbisError::NotVorbis => "Bitstream does not contain any Vorbis data",
-            &VorbisError::VersionMismatch => "Vorbis version mismatch",
-            &VorbisError::BadHeader => "Invalid Vorbis bitstream header",
-            &VorbisError::InitialFileHeadersCorrupt => "Initial file headers are corrupt",
-            &VorbisError::Hole => "Interruption of data",
-        }
-    }
-
-    fn cause(&self) -> Option<&std::error::Error> {
-        match self {
-            &VorbisError::ReadError(ref err) => Some(err as &std::error::Error),
-            _ => None
+            VorbisError::ReadError(ref err) => Some(err),
+            _ => None,
         }
     }
 }
 
 impl std::fmt::Display for VorbisError {
     fn fmt(&self, fmt: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
-        write!(fmt, "{}", std::error::Error::description(self))
+        let description = match self {
+            VorbisError::ReadError(_) => "A read from media returned an error",
+            VorbisError::NotVorbis => "Bitstream does not contain any Vorbis data",
+            VorbisError::VersionMismatch => "Vorbis version mismatch",
+            VorbisError::BadHeader => "Invalid Vorbis bitstream header",
+            VorbisError::InitialFileHeadersCorrupt => "Initial file headers are corrupt",
+            VorbisError::Hole => "Interruption of data",
+        };
+
+        fmt.write_str(description)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,7 +113,7 @@ impl<R> Decoder<R> where R: Read + Seek {
 
             let ptr = ptr as *mut u8;
 
-            let data: &mut DecoderData<R> = unsafe { std::mem::transmute(datasource) };
+            let data: &mut DecoderData<R> = unsafe { &mut *(datasource as *mut _) };
 
             let buffer = unsafe { slice::from_raw_parts_mut(ptr as *mut u8, nmemb as usize) };
 
@@ -132,7 +132,7 @@ impl<R> Decoder<R> where R: Read + Seek {
         extern fn seek_func<R>(datasource: *mut libc::c_void, offset: tremor_sys::ogg_int64_t,
             whence: libc::c_int) -> libc::c_int where R: Read + Seek
         {
-            let data: &mut DecoderData<R> = unsafe { std::mem::transmute(datasource) };
+            let data: &mut DecoderData<R> = unsafe { &mut *(datasource as *mut _) };
 
             let result = match whence {
                 libc::SEEK_SET => data.reader.seek(io::SeekFrom::Start(offset as u64)),
@@ -150,7 +150,7 @@ impl<R> Decoder<R> where R: Read + Seek {
         extern fn tell_func<R>(datasource: *mut libc::c_void) -> libc::c_long
             where R: Read + Seek
         {
-            let data: &mut DecoderData<R> = unsafe { std::mem::transmute(datasource) };
+            let data: &mut DecoderData<R> = unsafe { &mut *(datasource as *mut DecoderData<R>) };
             data.reader.seek(io::SeekFrom::Current(0)).map(|v| v as libc::c_long).unwrap_or(-1)
         }
 
@@ -239,7 +239,7 @@ impl<R> Decoder<R> where R: Read + Seek {
                 let infos = unsafe { tremor_sys::ov_info(&mut self.data.vorbis,
                     self.data.current_logical_bitstream) };
 
-                let infos: &tremor_sys::vorbis_info = unsafe { std::mem::transmute(infos) };
+                let infos: &tremor_sys::vorbis_info = unsafe { &*infos };
 
                 Some(Ok(Packet {
                     data: buffer,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,8 +5,6 @@ extern crate ogg_sys;
 use std::io::{self, Read, Seek};
 use std::mem::MaybeUninit;
 
-use tremor_sys::OggVorbis_File;
-
 /// Allows you to decode a sound file stream into packets.
 pub struct Decoder<R> where R: Read + Seek {
     // further informations are boxed so that a pointer can be passed to callbacks

--- a/src/tremor_sys.rs
+++ b/src/tremor_sys.rs
@@ -7,8 +7,8 @@ extern crate libc;
 use libc::{c_int, c_long, c_char, c_void};
 
 pub use ogg_sys::ogg_int64_t;
-pub type ogg_int32_t = libc::int32_t;
-pub type ogg_uint32_t = libc::uint32_t;
+pub type ogg_int32_t = i32;
+pub type ogg_uint32_t = u32;
 
 pub const OV_FALSE: c_int = -1;
 pub const OV_EOF: c_int = -2;

--- a/src/tremor_sys.rs
+++ b/src/tremor_sys.rs
@@ -4,7 +4,7 @@
 
 extern crate libc;
 
-use libc::{c_int, c_long, c_char, c_void};
+use libc::{c_char, c_int, c_long, c_void};
 
 pub use ogg_sys::ogg_int64_t;
 pub type ogg_int32_t = i32;
@@ -102,11 +102,11 @@ pub struct vorbis_comment {
 
 #[repr(C)]
 pub struct ov_callbacks {
-    pub read_func: extern fn(*mut c_void, libc::size_t, libc::size_t, *mut c_void)
-        -> libc::size_t,
-    pub seek_func: extern fn(*mut c_void, ogg_int64_t, c_int) -> c_int,
-    pub close_func: extern fn(*mut c_void) -> c_int,
-    pub tell_func: extern fn(*mut c_void) -> c_long,
+    pub read_func:
+        extern "C" fn(*mut c_void, libc::size_t, libc::size_t, *mut c_void) -> libc::size_t,
+    pub seek_func: extern "C" fn(*mut c_void, ogg_int64_t, c_int) -> c_int,
+    pub close_func: extern "C" fn(*mut c_void) -> c_int,
+    pub tell_func: extern "C" fn(*mut c_void) -> c_long,
 }
 
 pub const NOTOPEN: c_int = 0;
@@ -146,19 +146,35 @@ pub struct OggVorbis_File {
     pub callbacks: ov_callbacks,
 }
 
-extern {
+extern "C" {
     pub fn ov_clear(vf: *mut OggVorbis_File) -> c_int;
-    pub fn ov_open(f: *mut libc::FILE, vf: *mut OggVorbis_File, initial: *const c_char,
-        ibytes: c_long) -> c_int;
-    pub fn ov_open_callbacks(datasource: *mut c_void, vf: *mut OggVorbis_File,
-        initial: *const c_char, ibytes: c_long, callbacks: ov_callbacks)
-        -> c_int;
+    pub fn ov_open(
+        f: *mut libc::FILE,
+        vf: *mut OggVorbis_File,
+        initial: *const c_char,
+        ibytes: c_long,
+    ) -> c_int;
+    pub fn ov_open_callbacks(
+        datasource: *mut c_void,
+        vf: *mut OggVorbis_File,
+        initial: *const c_char,
+        ibytes: c_long,
+        callbacks: ov_callbacks,
+    ) -> c_int;
 
-    pub fn ov_test(f: *mut libc::FILE, vf: *mut OggVorbis_File, initial: *const c_char,
-        ibytes: c_long) -> c_int;
-    pub fn ov_test_callbacks(datasource: *mut c_void, vf: *mut OggVorbis_File,
-        initial: *const c_char, ibytes: c_long, callbacks: ov_callbacks)
-        -> c_int;
+    pub fn ov_test(
+        f: *mut libc::FILE,
+        vf: *mut OggVorbis_File,
+        initial: *const c_char,
+        ibytes: c_long,
+    ) -> c_int;
+    pub fn ov_test_callbacks(
+        datasource: *mut c_void,
+        vf: *mut OggVorbis_File,
+        initial: *const c_char,
+        ibytes: c_long,
+        callbacks: ov_callbacks,
+    ) -> c_int;
     pub fn ov_test_open(vf: *mut OggVorbis_File) -> c_int;
 
     pub fn ov_bitrate(vf: *mut OggVorbis_File, i: c_int) -> c_long;
@@ -184,7 +200,13 @@ extern {
     pub fn ov_info(vf: *mut OggVorbis_File, link: c_int) -> *mut vorbis_info;
     pub fn ov_comment(vf: *mut OggVorbis_File, link: c_int) -> *mut vorbis_comment;
 
-    pub fn ov_read(vf: *mut OggVorbis_File, buffer: *mut c_char, length: c_int,
-        bigendianp: c_int, word: c_int, sgned: c_int,
-        bitstream: *mut c_int) -> c_long;
+    pub fn ov_read(
+        vf: *mut OggVorbis_File,
+        buffer: *mut c_char,
+        length: c_int,
+        bigendianp: c_int,
+        word: c_int,
+        sgned: c_int,
+        bitstream: *mut c_int,
+    ) -> c_long;
 }


### PR DESCRIPTION
This PR is based on @John2143's PR #1, see there for more details. I rebased it on the `v0.1.0` tag which was not in master. I got rid of a dangerous use of `mem::transmute` by using `MaybeUninit`. Additionally, I fixed some deprecations and eventually ran rustfmt.